### PR TITLE
DPD: fix crash due to NULL itemPool in Prune

### DIFF
--- a/src/common/smfDpd.cpp
+++ b/src/common/smfDpd.cpp
@@ -445,6 +445,16 @@ void SmfDpdTable::PacketIdTable::Prune(unsigned int           currentTime,
             if (NULL != poolArray)
             {
                 ProtoTree::ItemPool* itemPool = poolArray[staleEntry->GetPktIdLength()];
+                if (NULL == itemPool)
+                {
+                    if (NULL == (itemPool = new ProtoTree::ItemPool()))
+                    {
+                        PLOG(PL_WARN, "SmfDpdTable::PacketIdTable::Prune() new itemPool error: %s\n", GetErrorString());
+                        delete staleEntry;
+                        continue;
+                    }
+                    poolArray[staleEntry->GetPktIdLength()] = itemPool;
+                }
                 itemPool->Put(*staleEntry);
             }
             else


### PR DESCRIPTION
During DPD packet ID table pruning, entries may get recycled
with new packet ID size where a new poolArray slot hasn't
been created yet for that packet entry. In that case, create
a new itemPool and save it to the array.

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>